### PR TITLE
Bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "react-router-manager",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "3.2.2",
+      "version": "3.3.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.12.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "react-router-manager",
       "version": "3.3.0",
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://goodhood.eu",
   "repository": "goodhood-eu/react-router-manager",
   "bugs": "https://github.com/goodhood-eu/react-router-manager/issues",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "keywords": [
     "react",
     "router",


### PR DESCRIPTION
Why? The latest version on npm is [3.3.0-beta.0](https://www.npmjs.com/package/react-router-manager/v/3.3.0-beta.0), which can't be unpublished. As a result, the latest version cannot be reverted to the previous stable version.

I'm happy to take suggestions on how to resolve this.